### PR TITLE
Update FocusHelper.js

### DIFF
--- a/src/FocusHelper/widget/FocusHelper.js
+++ b/src/FocusHelper/widget/FocusHelper.js
@@ -157,7 +157,7 @@ define([
         },
 
         // set the focus on the element
-        _setFocusOnInput(inputNode) { 
+        _setFocusOnInput: function(inputNode) { 
             inputNode.focus();
             this._setFocus = false;
 


### PR DESCRIPTION
fix syntax on _setFocusOnInput function (broke in IE11)

I recommend you merge this request, rebuild, verify, and release an update to the App Store!